### PR TITLE
leave ctrlp entries searchable despite presence of unprintable characters

### DIFF
--- a/autoload/ctrlp/commandline.vim
+++ b/autoload/ctrlp/commandline.vim
@@ -62,7 +62,7 @@ call add(g:ctrlp_ext_vars, {
 "
 function! ctrlp#{s:n}#init()
 	let num = histnr('cmd')
-	let line = histget('cmd', num)
+	let line = strtrans(histget('cmd', num))
 	let lines = []
 	while num >= 1
 		if line != ''


### PR DESCRIPTION


See also https://github.com/sgur/ctrlp-extensions.vim/pull/10